### PR TITLE
Add CI job to build rubberband

### DIFF
--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -25,7 +25,9 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_linux
-        path: rubberband/ build/
+        path: |
+          rubberband
+          build
 
   macos:
     runs-on: macos-latest
@@ -42,7 +44,9 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_macos
-        path: rubberband/ build/
+        path: |
+          rubberband
+          build
 
   windows:
     runs-on: windows-latest
@@ -63,4 +67,6 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows
-        path: rubberband/ build/
+        path: |
+          rubberband
+          build

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         repository: ${{ env.RUBBERBAND_REPO }}
         ref: ${{ env.RUBBERBAND_VERSION }}
-    - run: apt install meson
+    - run: sudo apt update && sudo apt install -y meson
     - name: Build
       run: |
         meson setup build ${{ env.RUBBERBAND_FLAGS }}

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -7,8 +7,47 @@ on:
 env:
   RUBBERBAND_REPO: breakfastquay/rubberband
   RUBBERBAND_VERSION: 'v4.0.0'
+  RUBBERBAND_FLAGS: -Djni=disabled -Dcmdline=disabled -Dtests=disabled
 
 jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.RUBBERBAND_REPO }}
+        ref: ${{ env.RUBBERBAND_VERSION }}
+    - run: apt install meson
+    - name: Build
+      run: |
+        meson setup build ${{ env.RUBBERBAND_FLAGS }}
+        ninja -C build
+    - name: Prepare artifact
+      run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_linux.tar.gz rubberband build
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rubberband_${{ env.RUBBERBAND_VERSION }}_linux
+        path: rubberband_${{ env.RUBBERBAND_VERSION }}_linux.tar.gz
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.RUBBERBAND_REPO }}
+        ref: ${{ env.RUBBERBAND_VERSION }}
+    - run: brew install meson ninja
+    - name: Build
+      run: |
+        meson setup build ${{ env.RUBBERBAND_FLAGS }}
+        ninja -C build
+    - name: Prepare artifact
+      run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_macos.tar.gz rubberband build
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rubberband_${{ env.RUBBERBAND_VERSION }}_macos
+        path: rubberband_${{ env.RUBBERBAND_VERSION }}_macos.tar.gz
+
   windows:
     runs-on: windows-latest
     steps:
@@ -21,10 +60,12 @@ jobs:
       with:
         python-version: '3.10'
     - run: pip install meson ninja
-    - run: |
-        meson setup build
+    - name: Build
+      run: |
+        meson setup build ${{ env.RUBBERBAND_FLAGS }}
         ninja -C build
-    - run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz rubberband build
+    - name: Prepare artifact
+      run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz rubberband build
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_linux
-        path: rubberband build
+        path: rubberband/ build/
 
   macos:
     runs-on: macos-latest
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_macos
-        path: rubberband build
+        path: rubberband/ build/
 
   windows:
     runs-on: windows-latest
@@ -63,4 +63,4 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows
-        path: rubberband build
+        path: rubberband/ build/

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -25,7 +25,7 @@ jobs:
         meson setup build
         ninja -C build
     - run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz rubberband build
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows
         path: rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -22,12 +22,10 @@ jobs:
       run: |
         meson setup build ${{ env.RUBBERBAND_FLAGS }}
         ninja -C build
-    - name: Prepare artifact
-      run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_linux.tar.gz rubberband build
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_linux
-        path: rubberband_${{ env.RUBBERBAND_VERSION }}_linux.tar.gz
+        path: rubberband build
 
   macos:
     runs-on: macos-latest
@@ -41,12 +39,10 @@ jobs:
       run: |
         meson setup build ${{ env.RUBBERBAND_FLAGS }}
         ninja -C build
-    - name: Prepare artifact
-      run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_macos.tar.gz rubberband build
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_macos
-        path: rubberband_${{ env.RUBBERBAND_VERSION }}_macos.tar.gz
+        path: rubberband build
 
   windows:
     runs-on: windows-latest
@@ -64,9 +60,7 @@ jobs:
       run: |
         meson setup build ${{ env.RUBBERBAND_FLAGS }}
         ninja -C build
-    - name: Prepare artifact
-      run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz rubberband build
     - uses: actions/upload-artifact@v4
       with:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows
-        path: rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz
+        path: rubberband build

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -1,0 +1,31 @@
+name: Build lib
+on:
+  push:
+    paths:
+      - .github/workflows/build_lib.yml
+
+env:
+  RUBBERBAND_REPO: breakfastquay/rubberband
+  RUBBERBAND_VERSION: 'v4.0.0'
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.RUBBERBAND_REPO }}
+        ref: ${{ env.RUBBERBAND_VERSION }}
+    - uses: microsoft/setup-msbuild@v2
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - run: pip install meson ninja
+    - run: |
+        meson setup build
+        ninja -C build
+    - run: tar -czvf rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz rubberband build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows
+        path: rubberband_${{ env.RUBBERBAND_VERSION }}_windows.tar.gz

--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -27,7 +27,7 @@ jobs:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_linux
         path: |
           rubberband
-          build
+          build/librubberband*
 
   macos:
     runs-on: macos-latest
@@ -46,7 +46,7 @@ jobs:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_macos
         path: |
           rubberband
-          build
+          build/librubberband*
 
   windows:
     runs-on: windows-latest
@@ -69,4 +69,4 @@ jobs:
         name: rubberband_${{ env.RUBBERBAND_VERSION }}_windows
         path: |
           rubberband
-          build
+          build/librubberband*


### PR DESCRIPTION
Per title. Right now use default FFT and resampler option (vDSP from Accelerate for Macos FFT, and built-in stuff for everything else). Need to investigate if we use FFTW3, then we can static link to Python extension.